### PR TITLE
Se agrega módulo de inyección de dependencias

### DIFF
--- a/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/FactoryLoadException.cs
+++ b/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/FactoryLoadException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Framework.DI
+{
+    public class FactoryLoadException : Exception
+    {
+        private const string _message = "Couldn't load classes for loader of type {0}";
+
+        public Type Type { get; private set; }
+
+        public FactoryLoadException(Type type) : base(_message)
+        { 
+            this.Type = type;
+        }
+
+        public FactoryLoadException(Type type, Exception exception) : base(_message, exception)
+        {
+            this.Type = type;
+        }
+    }
+}

--- a/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/FactoryLoader.cs
+++ b/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/FactoryLoader.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+
+namespace Framework.DI
+{
+    public static class FactoryLoader
+    {
+        public static void LoadAll()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                var loaderTypes = assembly.GetTypes()
+                    .Where(t => typeof(IFactoryLoader).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
+
+                foreach (var type in loaderTypes)
+                {
+                    try
+                    {
+                        var instance = Activator.CreateInstance(type) as IFactoryLoader;
+                        instance?.LoadClasses();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new FactoryLoadException(type, ex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/IFactoryLoader.cs
+++ b/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/DI/IFactoryLoader.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Framework.DI
+{
+    public interface IFactoryLoader
+    {
+        void LoadClasses();
+    }
+}

--- a/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/Framework.Interfaces.csproj
+++ b/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/Framework.Interfaces.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{596EC40A-5802-446C-A2AD-D07AAF4A1B17}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Framework</RootNamespace>
+    <AssemblyName>Framework.Interfaces</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DI\FactoryLoader.cs" />
+    <Compile Include="DI\FactoryLoadException.cs" />
+    <Compile Include="DI\IFactoryLoader.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/Properties/AssemblyInfo.cs
+++ b/Code/2025_2C_UAI_IDS_Ramirez_Chathokhine/Framework.Interfaces/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// La información general de un ensamblado se controla mediante el siguiente 
+// conjunto de atributos. Cambie estos valores de atributo para modificar la información
+// asociada con un ensamblado.
+[assembly: AssemblyTitle("Framework.Interfaces")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Framework.Interfaces")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Si establece ComVisible en false, los tipos de este ensamblado no estarán visibles 
+// para los componentes COM.  Si es necesario obtener acceso a un tipo en este ensamblado desde 
+// COM, establezca el atributo ComVisible en true en este tipo.
+[assembly: ComVisible(false)]
+
+// El siguiente GUID sirve como id. de typelib si este proyecto se expone a COM.
+[assembly: Guid("596ec40a-5802-446c-a2ad-d07aaf4a1b17")]
+
+// La información de versión de un ensamblado consta de los cuatro valores siguientes:
+//
+//      Versión principal
+//      Versión secundaria
+//      Número de compilación
+//      Revisión
+//
+// Puede especificar todos los valores o usar los valores predeterminados de número de compilación y de revisión
+// utilizando el carácter "*", como se muestra a continuación:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Se agrega módulo para guardar interfaces genéricas y poder manejar inyección de dependencias para los componentes de cada módulo (5° principio de SOLID).
La implementación se hace por una clase que herede la interfaz IFactoryLoader, que deberá tener asociado un Factory con sus dependencias inyectadas.
TODO:
- Migrar interfaces de módulos a Framework.Interfaces